### PR TITLE
add MonthDayAtTime method

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,34 +1,44 @@
-'use strict';
+"use strict";
 
 Object.defineProperty(exports, "__esModule", {
-  value: true
+  value: true,
 });
 exports.year = exports.add = exports.timeago = exports.monthDayYearAtTime = exports.monthDayYear = undefined;
 
-var _moment = require('moment');
+var _moment = require("moment");
 
 var _moment2 = _interopRequireDefault(_moment);
 
-require('moment-timezone');
+require("moment-timezone");
 
-function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+function _interopRequireDefault(obj) {
+  return obj && obj.__esModule ? obj : { default: obj };
+}
 
-var monthDayYear = exports.monthDayYear = function monthDayYear(timestamp, timezone) {
-  return !timezone ? (0, _moment2.default)(timestamp).format('MMMM Do, YYYY') : (0, _moment2.default)(timestamp).tz(timezone).format('MMMM Do, YYYY');
-};
+var monthDayYear = (exports.monthDayYear = function monthDayYear(timestamp, timezone) {
+  return !timezone ? (0, _moment2.default)(timestamp).format("MMMM Do, YYYY") : (0, _moment2.default)(timestamp).tz(timezone).format("MMMM Do, YYYY");
+});
 
-var monthDayYearAtTime = exports.monthDayYearAtTime = function monthDayYearAtTime(timestamp, timezone) {
-  return !timezone ? (0, _moment2.default)(timestamp).format('MMMM Do, YYYY [at] hh:mm a') : (0, _moment2.default)(timestamp).tz(timezone).format('MMMM Do, YYYY [at] hh:mm a');
-};
+var monthDayYearAtTime = (exports.monthDayYearAtTime = function monthDayYearAtTime(timestamp, timezone) {
+  return !timezone
+    ? (0, _moment2.default)(timestamp).format("MMMM Do, YYYY [at] hh:mm a")
+    : (0, _moment2.default)(timestamp).tz(timezone).format("MMMM Do, YYYY [at] hh:mm a");
+});
 
-var timeago = exports.timeago = function timeago(timestamp, timezone) {
+var monthDayAtTime = (exports.monthDayAtTime = function monthDayAtTime(timestamp, timezone) {
+  return !timezone
+    ? (0, _moment2.default)(timestamp).format("MMMM Do,[at] hh:mm a")
+    : (0, _moment2.default)(timestamp).tz(timezone).format("MMMM Do,[at] hh:mm a");
+});
+
+var timeago = (exports.timeago = function timeago(timestamp, timezone) {
   return !timezone ? (0, _moment2.default)(timestamp).fromNow() : (0, _moment2.default)(timestamp).tz(timezone).fromNow();
-};
+});
 
-var add = exports.add = function add(timestamp, amount, range, timezone) {
+var add = (exports.add = function add(timestamp, amount, range, timezone) {
   return !timezone ? (0, _moment2.default)(timestamp).add(amount, range).format() : (0, _moment2.default)(timestamp).tz(timezone).add(amount, range).format();
-};
+});
 
-var year = exports.year = function year(timestamp, timezone) {
-  return !timezone ? (0, _moment2.default)(timestamp).format('YYYY') : (0, _moment2.default)(timestamp).tz(timezone).format('YYYY');
-};
+var year = (exports.year = function year(timestamp, timezone) {
+  return !timezone ? (0, _moment2.default)(timestamp).format("YYYY") : (0, _moment2.default)(timestamp).tz(timezone).format("YYYY");
+});

--- a/index.js
+++ b/index.js
@@ -15,6 +15,10 @@ function _interopRequireDefault(obj) {
   return obj && obj.__esModule ? obj : { default: obj };
 }
 
+var monthDay = (exports.monthDay = function monthDay(timestamp, timezone) {
+  return !timezone ? (0, _moment2.default)(timestamp).format("MMMM Do") : (0, _moment2.default)(timestamp).tz(timezone).format("MMMM Do");
+});
+
 var monthDayYear = (exports.monthDayYear = function monthDayYear(timestamp, timezone) {
   return !timezone ? (0, _moment2.default)(timestamp).format("MMMM Do, YYYY") : (0, _moment2.default)(timestamp).tz(timezone).format("MMMM Do, YYYY");
 });

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,8 @@
 import moment from "moment";
 import "moment-timezone";
 
+export const monthDay = (timestamp, timezone) => (!timezone ? moment(timestamp).format("MMMM Do, YYYY") : moment(timestamp).tz(timezone).format("MMMM Do"));
+
 export const monthDayYear = (timestamp, timezone) =>
   !timezone ? moment(timestamp).format("MMMM Do, YYYY") : moment(timestamp).tz(timezone).format("MMMM Do, YYYY");
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,27 +1,17 @@
-import moment from 'moment';
-import 'moment-timezone';
+import moment from "moment";
+import "moment-timezone";
 
-export const monthDayYear = (timestamp, timezone) => (
-  !timezone ? moment(timestamp).format('MMMM Do, YYYY') :
-  moment(timestamp).tz(timezone).format('MMMM Do, YYYY')
-);
+export const monthDayYear = (timestamp, timezone) =>
+  !timezone ? moment(timestamp).format("MMMM Do, YYYY") : moment(timestamp).tz(timezone).format("MMMM Do, YYYY");
 
-export const monthDayYearAtTime = (timestamp, timezone) => (
-  !timezone ? moment(timestamp).format('MMMM Do, YYYY [at] hh:mm a') :
-  moment(timestamp).tz(timezone).format('MMMM Do, YYYY [at] hh:mm a')
-);
+export const monthDayYearAtTime = (timestamp, timezone) =>
+  !timezone ? moment(timestamp).format("MMMM Do, YYYY [at] hh:mm a") : moment(timestamp).tz(timezone).format("MMMM Do, YYYY [at] hh:mm a");
+export const monthDayAtTime = (timestamp, timezone) =>
+  !timezone ? moment(timestamp).format("MMMM Do,[at] hh:mm a") : moment(timestamp).tz(timezone).format("MMMM Do,[at] hh:mm a");
 
-export const timeago = (timestamp, timezone) => (
-  !timezone ? moment(timestamp).fromNow() :
-  moment(timestamp).tz(timezone).fromNow()
-);
+export const timeago = (timestamp, timezone) => (!timezone ? moment(timestamp).fromNow() : moment(timestamp).tz(timezone).fromNow());
 
-export const add = (timestamp, amount, range, timezone) =>(
-  !timezone ? moment(timestamp).add(amount, range).format() :
-  moment(timestamp).tz(timezone).add(amount, range).format()
-);
+export const add = (timestamp, amount, range, timezone) =>
+  !timezone ? moment(timestamp).add(amount, range).format() : moment(timestamp).tz(timezone).add(amount, range).format();
 
-export const year = (timestamp, timezone) =>(
-  !timezone ? moment(timestamp).format('YYYY') :
-  moment(timestamp).tz(timezone).format('YYYY')
-);
+export const year = (timestamp, timezone) => (!timezone ? moment(timestamp).format("YYYY") : moment(timestamp).tz(timezone).format("YYYY"));


### PR DESCRIPTION
Hey Ryan,
I went into your package and added a method to return a MonthDayAtTime - I realized that when I push to production the NPM package on my local won't carry over and would need an update to the NPM package or I can create my own utility with the source code ?- I saw CheatCode - you were not kidding on the rebrand! wow.- sad to see pup go, but with Meteor not as mainstream and good packages for react- CRA, redux templates etc. I think it does make sense :)  